### PR TITLE
Enhanced Delete of Points Method in API: Removing Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## [Unreleased]
+
+## [0.9.6] - 2024-01-13
+- Updated Points#delete() method: Removed the requirement to specify points: in parameters. Now generates an error if neither points: nor filters: are provided, aligning with delete_points documentation standards.
+
 ## [0.9.5] - 2024-01-12
 - Bugfix: ArgumentError for filter in points delete 
 ## [0.9.4] - 2023-08-31

--- a/lib/qdrant/points.rb
+++ b/lib/qdrant/points.rb
@@ -46,16 +46,21 @@ module Qdrant
     # Delete points
     def delete(
       collection_name:,
-      points:, wait: nil,
+      points: nil,
+      wait: nil,
       ordering: nil,
       filter: nil
     )
+
+      raise ArgumentError, "Either points or filter should be provided" if points.nil? && filter.nil?
+
       response = client.connection.post("collections/#{collection_name}/#{PATH}/delete") do |req|
         req.params["wait"] = wait unless wait.nil?
         req.params["ordering"] = ordering unless ordering.nil?
 
         req.body = {}
-        req.body["points"] = points
+
+        req.body["points"] = points unless filter.nil?
         req.body["filter"] = filter unless filter.nil?
       end
       response.body

--- a/lib/qdrant/version.rb
+++ b/lib/qdrant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Qdrant
-  VERSION = "0.9.5"
+  VERSION = "0.9.6"
 end


### PR DESCRIPTION
I have modified the delete method by removing the requirement to include points: in the parameters. Now, if neither points: nor filters: are provided, an error will be generated. This change is in line with the guidelines provided in the [delete_points](https://qdrant.github.io/qdrant/redoc/index.html#tag/points/operation/delete_points) documentation.